### PR TITLE
Add new tool (Stanza) and link updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Sinhala and Tamil
 * [Sinhala skipgram model](https://github.com/theisuru/sentiment-tagger/tree/master/corpus/analyzed/saved_models)
 * [Sinhala TTS Recipe](https://github.com/google/language-resources/tree/master/si/festvox)
 * [Sinhala ASR Recipe](https://github.com/google/asr-recipes)
+* [Stanza - Python NLP package for liguistic analysis](https://stanfordnlp.github.io/stanza/index.html) - Supports multiple languages including tamil
+
 
 
 #### Research Groups

--- a/README.md
+++ b/README.md
@@ -54,25 +54,24 @@ Sinhala and Tamil
 * [Databricks Dolly 15k Sinhala Dataset](https://huggingface.co/datasets/Suchinthana/databricks-dolly-15k-sinhala) a machine translated version of Databricks 15k dataset.
 * [Sinhala Question Answering Dataset 1k](https://huggingface.co/datasets/Suchinthana/Sinhala-QA-Translate) a Sinhala QA dataset with English translations.
 * [Sinhala Wikipedia 202306](https://huggingface.co/datasets/Suchinthana/si-wikipedia) Sinhala wikipedia according to 2023 June dump in huggingface datasets format.
+* Fasttext bulit by Facebook using wikipedia.
+  * Sinhala: [bin](https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.si.300.bin.gz), [text](https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.si.300.vec.gz)
+  * Tamil: [bin](https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.ta.300.bin.gz), [text](https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.ta.300.vec.gz)
+* Fasttext bulit by CSE, UoM using wikipedia, News, and official government documents
+  * Sinhala: [bin](https://dms.mrt.ac.lk/index.php/s/4CtG8JoNGcdTtxe/download?path=%2F&files=ftext_si_18-02-07-model.bin)
+  * Tamil: [bin](https://dms.mrt.ac.lk/index.php/s/4CtG8JoNGcdTtxe/download?path=%2F&files=ftext_ti_18-02-07-model.bin)
+* Sinhala-English parallel corpora
+  * [Subtitle pairs (600k+)](http://bit.ly/2KsFQxm)
+  * Sentences pairs (45k+): [GNOME](http://bit.ly/2Z8q0fo), [KDE](http://bit.ly/2WLY6bI), and [Ubuntu](http://bit.ly/2wLVZGt)  
+* [Filtered Sinhala Wikipedia (155k+ sentences)](http://bit.ly/2EQZ7oM)
+* [Sinhala common crawl (5m+ sentences)](http://bit.ly/2ZaQFZo)
+* [Sinhala-POS-Data](https://github.com/nlpc-uom/Sinhala-POS-Data)
+* [Sinhala-Tamil-Aligned-Parallel-Corpus](https://github.com/nlpc-uom/Sinhala-Tamil-Aligned-Parallel-Corpus)
+* [Sinhala Lexicon](https://github.com/google/language-resources/blob/master/si/data/lexicon.tsv)
+* [Sinhala TTS Textnorm grammer](https://github.com/google/language-resources/tree/master/si/textnorm)
+* [Sinhala TTS Phonology](https://github.com/google/language-resources/blob/master/si/festvox/ipa_phonology.json)
+* [Sinhala G2P](https://github.com/google/language-resources/blob/master/si/si-si_FONIPA.txt)
 
-* Fasttext bulit by Facebook using wikipedia. 
-    * Sinhala: [bin](https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.si.300.bin.gz), [text](https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.si.300.vec.gz)
-    * Tamil: [bin](https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.ta.300.bin.gz), [text](https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.ta.300.vec.gz)
- * Fasttext bulit by CSE, UoM using wikipedia, News, and official government documents
-    * Sinhala: [bin](https://dms.mrt.ac.lk/index.php/s/4CtG8JoNGcdTtxe/download?path=%2F&files=ftext_si_18-02-07-model.bin)
-    * Tamil: [bin](https://dms.mrt.ac.lk/index.php/s/4CtG8JoNGcdTtxe/download?path=%2F&files=ftext_ti_18-02-07-model.bin)
- * Sinhala-English parallel corpora
-    * [Subtitle pairs (600k+)](http://bit.ly/2KsFQxm) 
-    * Sentences pairs (45k+): [GNOME](http://bit.ly/2Z8q0fo), [KDE](http://bit.ly/2WLY6bI) , and [Ubuntu](http://bit.ly/2wLVZGt)  
- * [Filtered Sinhala Wikipedia (155k+ sentences)](http://bit.ly/2EQZ7oM)
- * [Sinhala common crawl (5m+ sentences)](http://bit.ly/2ZaQFZo)
- * [Sinhala-POS-Data](https://github.com/nlpc-uom/Sinhala-POS-Data)
- * [Sinhala-Tamil-Aligned-Parallel-Corpus](https://github.com/nlpc-uom/Sinhala-Tamil-Aligned-Parallel-Corpus)
- * [Sinhala Lexicon](https://github.com/google/language-resources/blob/master/si/data/lexicon.tsv)
- * [Sinhala TTS Textnorm grammer](https://github.com/google/language-resources/tree/master/si/textnorm)
- * [Sinhala TTS Phonology](https://github.com/google/language-resources/blob/master/si/festvox/ipa_phonology.json)
- * [Sinhala G2P](https://github.com/google/language-resources/blob/master/si/si-si_FONIPA.txt)
- 
 
 
 #### Tools
@@ -82,7 +81,7 @@ Sinhala and Tamil
 * [National Langauges Processing Centre (UoM) on Github](https://github.com/cnlpuom)
 * [Sinhala Sentence Similarity Measurement](https://github.com/suralk/SinhalaSentenceSimilarityMeasurement)
 * [Tamil Emotion Tweet Scraper](https://github.com/Jenarthanan14/Tamil-Sinhala-Emotion-Analysis/tree/master/TamilEmotionTweetScraper)
-* [Morphological analyser and tokenizer for Sinhala nuons (SinLing)](https://github.com/ysenarath/SinLing)
+* [Morphological analyser and tokenizer for Sinhala nouns (SinLing)](https://github.com/ysenarath/SinLing)
 * [Sinhala-and-Tamil-NER](https://github.com/nlpc-uom/Sinhala-and-Tamil-NER)
 * [Tamil-Tokeniser](https://github.com/nlpc-uom/Tamil-Tokeniser)
 * [Sinhala-Tokeniser](https://github.com/ysenarath/sinling/tree/master/bin)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Sinhala and Tamil
 * [Facebook Low Resource MT Benchmark (FLoRes)](https://github.com/facebookresearch/flores)
 * [Large Sinhala ASR training data set](http://openslr.org/52)
 * [Sinhala TTS](http://openslr.org/30/)
-* [SinMin Dataset](http://ix.cs.uoregon.edu/~nisansa/#DataSets)
+* [SinMin Dataset](https://osf.io/a5quv/) - [more info](https://nisansads.staff.uom.lk/#DataSets>)
 * [Language Technology Research Lab University of Colombo School of Computing](http://ltrl.ucsc.lk/download-3/)
 * [Small Sinhala newes corpus](https://osf.io/tdb84/)
 * [Ananya Sinhala NER Dataset](https://github.com/suralk/AnanyaSinhalaNERDataset)
@@ -90,7 +90,6 @@ Sinhala and Tamil
 * [Sinhala TTS Recipe](https://github.com/google/language-resources/tree/master/si/festvox)
 * [Sinhala ASR Recipe](https://github.com/google/asr-recipes)
 * [Stanza - Python NLP package for liguistic analysis](https://stanfordnlp.github.io/stanza/index.html) - Supports multiple languages including tamil
-
 
 
 #### Research Groups

--- a/index.html
+++ b/index.html
@@ -1,112 +1,163 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>LK NLP</title>
-    <link href="https://ix.cs.uoregon.edu/~nisansa/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-    <link href="basic.css" rel="stylesheet">
-  </head>
-  <body>
-    <!-- Converted HTML (from Markdown) starts here. -->
-    <h2 id="metainfo">Meta info</h2>
-    <h4 id="objective">Objective</h4>
-    <p>Create a crowd-sourced repository for NLP sources for native languages of Sri Lanka.</p>
-    <h4 id="targetlanguages">Target languages</h4>
-    <p>Sinhala and Tamil</p>
-    <h4 id="whattoadd">What to add</h4>
-    <ul>
-      <li>Datasets</li>
-      <li>Research publications</li>
-      <li>Open source implementations</li>
-      <li>Useful articles, blog posts</li>
-      <li>Other linguistic resources (e.g. Sinhala/Tamil phonology)</li>
-      <li>Tools (or links to proposals) for crowdsourced data collection</li>
-    </ul>
-    <h4 id="howtocontribute">How to contribute</h4>
-    <ul>
-      <li>Send a pull request to <a href="https://github.com/lklangs/lklangs.github.io">lklangs.github.io</a> with your changes or send an email to lklangs2019@gmail.com</li>
-      <li>Use <a href="https://www.browserling.com/tools/markdown-to-html">Browserling tool</a> to generate HTML from <code>README.md</code>.</li>
-    </ul>
-    <h4 id="todo">To do</h4>
-    <ul>
-      <li>Resource templates</li>
-      <li>Structuring</li>
-      <li>Update website</li>
-    </ul>
-    <h2 id="resources">Resources</h2>
-    <h4 id="publications">Publications</h4>
-    <ul>
-      <li><a href="https://tico-19.github.io/data/paper/ticopaper.pdf">TICO-19: the Translation Initiative for COvid-19</a> 2020</li>
-      <li><a href="https://www.aclweb.org/anthology/D19-1632">The FLoRes Evaluation Datasets for Low-Resource Machine Translation: Nepali-English and Sinhala-English</a> 2019</li>
-      <li><a href="https://arxiv.org/pdf/1906.02358.pdf">Survey on Publicly Available Sinhala Natural Language Processing Tools and Research</a> 2019</li>
-      <li><a href="https://lirneasia.net/2019/04/natural-language-processing-for-government-problems-and-potential/">Natural Language Processing for Government: Problems and Potential</a> 2019</li>
-      <li><a href="https://arxiv.org/abs/1902.01382">Two New Evaluation Datasets for Low-Resource Machine Translation: Nepali-English and Sinhala-English</a></li>
-      <li><a href="https://www.researchgate.net/publication/277475828_Comparison_Between_Performance_of_Various_Database_Systems_for_Implementing_a_Language_Corpus">Comparison Between Performance of Various Database Systems for Implementing a Language Corpus</a> 2015</li>
-      <li><a href="https://www.researchgate.net/publication/306264442_Implementing_a_Corpus_for_Sinhala_Language">Implementing a Corpus for Sinhala Language</a> 2015</li>
-      <li><a href="https://www.researchgate.net/publication/329908360_Sinhala_Text_Classification_Observations_from_the_Perspective_of_a_Resource_Poor_Language">Sinhala Text Classification: Observations from the Perspective of a Resource Poor Language</a> 2015</li>
-      <li><a href="http://dl.lib.mrt.ac.lk/bitstream/handle/123/12501/Sinhala%20Handwriting%20Recognition%20Mechanism%20Using%20Zone%20Based%20Feature%20Extraction.pdf">Sinhala Handwriting Recognition Mechanism Using Zone Based Feature Extraction</a> 2015</li>
-      <li><a href="http://aclweb.org/anthology/U14-1018">Sinhala-Tamil Machine Translation: Towards better Translation Quality</a> 2014</li>
-      <li><a href="https://www.researchgate.net/publication/269465993_Building_a_WordNet_for_Sinhala">Building a WordNet for Sinhala</a> 2014</li>
-      <li><a href="https://pdfs.semanticscholar.org/9cba/8533b35dbfc3db35e30b801c778377fe0817.pdf">Corpus-based Sinhala Lexicon</a> 2009</li>
-    </ul>
-    <h4 id="datasets">Datasets</h4>
-    <ul>
-      <li><a href="https://tico-19.github.io/terminologies.html">Translation Initiative for COVID-19 (English-Sinhala)</a></li>
-      <li><a href="https://github.com/facebookresearch/flores">Facebook Low Resource MT Benchmark (FLoRes)</a></li>
-      <li><a href="http://openslr.org/52">Large Sinhala ASR training data set</a></li>
-      <li><a href="http://openslr.org/30/">Sinhala TTS</a></li>
-      <li><a href="http://ix.cs.uoregon.edu/~nisansa/#DataSets">SinMin Dataset</a></li>
-      <li><a href="http://ltrl.ucsc.lk/download-3/">Language Technology Research Lab University of Colombo School of Computing</a></li>
-      <li><a href="https://osf.io/tdb84/">Small Sinhala newes corpus</a></li>
-      <li><a href="https://github.com/suralk/AnanyaSinhalaNERDataset">Ananya Sinhala NER Dataset</a></li>
-      <li><a href="https://github.com/Jenarthanan14/Tamil-Sinhala-Emotion-Analysis">Tamil-Sinhala-Emotion-Analysis</a></li>
-      <li><a href="https://github.com/google-research-datasets/dakshina">Google Dakshina Dataset</a> for 12 South Asian languages including Sinhala and Tamil</li>
-      <li><a href="https://huggingface.co/datasets/Suchinthana/databricks-dolly-15k-sinhala">Databricks Dolly 15k Sinhala Dataset</a> a machine translated version of Databricks 15k dataset.</li>
-      <li><a href="https://huggingface.co/datasets/Suchinthana/Sinhala-QA-Translate">Sinhala Question Answering Dataset 1k</a> a Sinhala QA dataset with English translations.</li>
-      <li><a href="https://huggingface.co/datasets/Suchinthana/si-wikipedia">Sinhala Wikipedia 202306</a> Sinhala wikipedia according to 2023 June dump in huggingface datasets format.</li>
-      <li>
-        Fasttext bulit by Facebook using wikipedia. 
-        <ul>
-          <li>Sinhala: <a href="https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.si.300.bin.gz">bin</a>, <a href="https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.si.300.vec.gz">text</a></li>
-          <li>Tamil: <a href="https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.ta.300.bin.gz">bin</a>, <a href="https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.ta.300.vec.gz">text</a></li>
-          <li>Fasttext bulit by CSE, UoM using wikipedia, News, and official government documents</li>
-          <li>Sinhala: <a href="https://dms.mrt.ac.lk/index.php/s/4CtG8JoNGcdTtxe/download?path=%2F&amp;files=ftext_si_18-02-07-model.bin">bin</a></li>
-          <li>Tamil: <a href="https://dms.mrt.ac.lk/index.php/s/4CtG8JoNGcdTtxe/download?path=%2F&amp;files=ftext_ti_18-02-07-model.bin">bin</a></li>
-          <li>Sinhala-English parallel corpora</li>
-          <li><a href="http://bit.ly/2KsFQxm">Subtitle pairs (600k+)</a> </li>
-          <li>Sentences pairs (45k+): <a href="http://bit.ly/2Z8q0fo">GNOME</a>, <a href="http://bit.ly/2WLY6bI">KDE</a> , and <a href="http://bit.ly/2wLVZGt">Ubuntu</a>  </li>
-          <li><a href="http://bit.ly/2EQZ7oM">Filtered Sinhala Wikipedia (155k+ sentences)</a></li>
-          <li><a href="http://bit.ly/2ZaQFZo">Sinhala common crawl (5m+ sentences)</a></li>
-          <li><a href="https://github.com/nlpc-uom/Sinhala-POS-Data">Sinhala-POS-Data</a></li>
-          <li><a href="https://github.com/nlpc-uom/Sinhala-Tamil-Aligned-Parallel-Corpus">Sinhala-Tamil-Aligned-Parallel-Corpus</a></li>
-          <li><a href="https://github.com/google/language-resources/blob/master/si/data/lexicon.tsv">Sinhala Lexicon</a></li>
-          <li><a href="https://github.com/google/language-resources/tree/master/si/textnorm">Sinhala TTS Textnorm grammer</a></li>
-          <li><a href="https://github.com/google/language-resources/blob/master/si/festvox/ipa_phonology.json">Sinhala TTS Phonology</a></li>
-          <li><a href="https://github.com/google/language-resources/blob/master/si/si-si_FONIPA.txt">Sinhala G2P</a></li>
-        </ul>
-      </li>
-    </ul>
-    <h4 id="tools">Tools</h4>
-    <ul>
-      <li><a href="https://ucsc.cmb.ac.lk/machine-translation-system-sinhala-tamil-language-pair/">Machine Translation System for Sinhala -Tamil Language Pair</a></li>
-      <li><a href="https://github.com/precog-iiitd/MIDAS-NMT-English-Tamil">MIDAS-NMT-English-Tamil</a></li>
-      <li><a href="https://github.com/theisuru/sentiment-tagger">Sentiment Analysis of Sinhala News Comments</a></li>
-      <li><a href="https://github.com/cnlpuom">National Langauges Processing Centre (UoM) on Github</a></li>
-      <li><a href="https://github.com/suralk/SinhalaSentenceSimilarityMeasurement">Sinhala Sentence Similarity Measurement</a></li>
-      <li><a href="https://github.com/Jenarthanan14/Tamil-Sinhala-Emotion-Analysis/tree/master/TamilEmotionTweetScraper">Tamil Emotion Tweet Scraper</a></li>
-      <li><a href="https://github.com/ysenarath/SinLing">Morphological analyser and tokenizer for Sinhala nuons (SinLing)</a></li>
-      <li><a href="https://github.com/nlpc-uom/Sinhala-and-Tamil-NER">Sinhala-and-Tamil-NER</a></li>
-      <li><a href="https://github.com/nlpc-uom/Tamil-Tokeniser">Tamil-Tokeniser</a></li>
-      <li><a href="https://github.com/ysenarath/sinling/tree/master/bin">Sinhala-Tokeniser</a></li>
-      <li><a href="https://github.com/theisuru/sentiment-tagger/tree/master/corpus/analyzed/saved_models">Sinhala skipgram model</a></li>
-      <li><a href="https://github.com/google/language-resources/tree/master/si/festvox">Sinhala TTS Recipe</a></li>
-      <li><a href="https://github.com/google/asr-recipes">Sinhala ASR Recipe</a></li>
-    </ul>
-    <h4 id="researchgroups">Research Groups</h4>
-    <ul>
-      <li><a href="https://www.language.lk/en/">Local Languages Working Group by LK Domain Registry</a></li>
-      <li><a href="https://www.mrt.ac.lk/web/nlp">NLP gruop of UoM</a></li>
-      <li><a href="http://ltrl.ucsc.lk/">Language Technology Research Laboratory (LTRL) of UCSC</a></li>
-    </ul>
-    <!-- Converted HTML (from Markdown) ends here. -->
-  </body>
+
+<head>
+  <title>LK NLP</title>
+  <link href="https://ix.cs.uoregon.edu/~nisansa/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="basic.css" rel="stylesheet">
+</head>
+
+<body>
+  <!-- Converted HTML (from Markdown) starts here. -->
+  <h2 id="meta-info">Meta info</h2>
+  <h4 id="objective">Objective</h4>
+  <p>Create a crowd-sourced repository for NLP sources for native languages of Sri Lanka.</p>
+  <h4 id="target-languages">Target languages</h4>
+  <p>Sinhala and Tamil</p>
+  <h4 id="what-to-add">What to add</h4>
+  <ul>
+    <li>Datasets</li>
+    <li>Research publications</li>
+    <li>Open source implementations</li>
+    <li>Useful articles, blog posts</li>
+    <li>Other linguistic resources (e.g. Sinhala/Tamil phonology)</li>
+    <li>Tools (or links to proposals) for crowdsourced data collection</li>
+  </ul>
+  <h4 id="how-to-contribute">How to contribute</h4>
+  <ul>
+    <li>Send a pull request to <a href="https://github.com/lklangs/lklangs.github.io">lklangs.github.io</a> with your
+      changes or send an email to lklangs2019@gmail.com</li>
+    <li>Use <a href="https://www.browserling.com/tools/markdown-to-html">Browserling tool</a> to generate HTML from
+      <code>README.md</code>.</li>
+  </ul>
+  <h4 id="to-do">To do</h4>
+  <ul>
+    <li>Resource templates</li>
+    <li>Structuring</li>
+    <li>Update website</li>
+  </ul>
+  <h2 id="resources">Resources</h2>
+  <h4 id="publications">Publications</h4>
+  <ul>
+    <li><a href="https://tico-19.github.io/data/paper/ticopaper.pdf">TICO-19: the Translation Initiative for
+        COvid-19</a> 2020</li>
+    <li><a href="https://www.aclweb.org/anthology/D19-1632">The FLoRes Evaluation Datasets for Low-Resource Machine
+        Translation: Nepali-English and Sinhala-English</a> 2019</li>
+    <li><a href="https://arxiv.org/pdf/1906.02358.pdf">Survey on Publicly Available Sinhala Natural Language Processing
+        Tools and Research</a> 2019</li>
+    <li><a
+        href="https://lirneasia.net/2019/04/natural-language-processing-for-government-problems-and-potential/">Natural
+        Language Processing for Government: Problems and Potential</a> 2019</li>
+    <li><a href="https://arxiv.org/abs/1902.01382">Two New Evaluation Datasets for Low-Resource Machine Translation:
+        Nepali-English and Sinhala-English</a></li>
+    <li><a
+        href="https://www.researchgate.net/publication/277475828_Comparison_Between_Performance_of_Various_Database_Systems_for_Implementing_a_Language_Corpus">Comparison
+        Between Performance of Various Database Systems for Implementing a Language Corpus</a> 2015</li>
+    <li><a
+        href="https://www.researchgate.net/publication/306264442_Implementing_a_Corpus_for_Sinhala_Language">Implementing
+        a Corpus for Sinhala Language</a> 2015</li>
+    <li><a
+        href="https://www.researchgate.net/publication/329908360_Sinhala_Text_Classification_Observations_from_the_Perspective_of_a_Resource_Poor_Language">Sinhala
+        Text Classification: Observations from the Perspective of a Resource Poor Language</a> 2015</li>
+    <li><a
+        href="http://dl.lib.mrt.ac.lk/bitstream/handle/123/12501/Sinhala%20Handwriting%20Recognition%20Mechanism%20Using%20Zone%20Based%20Feature%20Extraction.pdf">Sinhala
+        Handwriting Recognition Mechanism Using Zone Based Feature Extraction</a> 2015</li>
+    <li><a href="http://aclweb.org/anthology/U14-1018">Sinhala-Tamil Machine Translation: Towards better Translation
+        Quality</a> 2014</li>
+    <li><a href="https://www.researchgate.net/publication/269465993_Building_a_WordNet_for_Sinhala">Building a WordNet
+        for Sinhala</a> 2014</li>
+    <li><a href="https://pdfs.semanticscholar.org/9cba/8533b35dbfc3db35e30b801c778377fe0817.pdf">Corpus-based Sinhala
+        Lexicon</a> 2009</li>
+  </ul>
+  <h4 id="datasets">Datasets</h4>
+  <ul>
+    <li><a href="https://tico-19.github.io/terminologies.html">Translation Initiative for COVID-19 (English-Sinhala)</a>
+    </li>
+    <li><a href="https://github.com/facebookresearch/flores">Facebook Low Resource MT Benchmark (FLoRes)</a></li>
+    <li><a href="http://openslr.org/52">Large Sinhala ASR training data set</a></li>
+    <li><a href="http://openslr.org/30/">Sinhala TTS</a></li>
+    <li><a href="https://osf.io/a5quv/">SinMin Dataset</a> - <a href="https://nisansads.staff.uom.lk/#DataSets">more
+        info</a></li>
+    <li><a href="http://ltrl.ucsc.lk/download-3/">Language Technology Research Lab University of Colombo School of
+        Computing</a></li>
+    <li><a href="https://osf.io/tdb84/">Small Sinhala newes corpus</a></li>
+    <li><a href="https://github.com/suralk/AnanyaSinhalaNERDataset">Ananya Sinhala NER Dataset</a></li>
+    <li><a href="https://github.com/Jenarthanan14/Tamil-Sinhala-Emotion-Analysis">Tamil-Sinhala-Emotion-Analysis</a>
+    </li>
+    <li><a href="https://github.com/google-research-datasets/dakshina">Google Dakshina Dataset</a> for 12 South Asian
+      languages including Sinhala and Tamil</li>
+    <li><a href="https://huggingface.co/datasets/Suchinthana/databricks-dolly-15k-sinhala">Databricks Dolly 15k Sinhala
+        Dataset</a> a machine translated version of Databricks 15k dataset.</li>
+    <li><a href="https://huggingface.co/datasets/Suchinthana/Sinhala-QA-Translate">Sinhala Question Answering Dataset
+        1k</a> a Sinhala QA dataset with English translations.</li>
+    <li><a href="https://huggingface.co/datasets/Suchinthana/si-wikipedia">Sinhala Wikipedia 202306</a> Sinhala
+      wikipedia according to 2023 June dump in huggingface datasets format.</li>
+    <li>Fasttext bulit by Facebook using wikipedia.<ul>
+        <li>Sinhala: <a href="https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.si.300.bin.gz">bin</a>, <a
+            href="https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.si.300.vec.gz">text</a></li>
+        <li>Tamil: <a href="https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.ta.300.bin.gz">bin</a>, <a
+            href="https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.ta.300.vec.gz">text</a></li>
+      </ul>
+    </li>
+    <li>Fasttext bulit by CSE, UoM using wikipedia, News, and official government documents<ul>
+        <li>Sinhala: <a
+            href="https://dms.mrt.ac.lk/index.php/s/4CtG8JoNGcdTtxe/download?path=%2F&amp;files=ftext_si_18-02-07-model.bin">bin</a>
+        </li>
+        <li>Tamil: <a
+            href="https://dms.mrt.ac.lk/index.php/s/4CtG8JoNGcdTtxe/download?path=%2F&amp;files=ftext_ti_18-02-07-model.bin">bin</a>
+        </li>
+      </ul>
+    </li>
+    <li>Sinhala-English parallel corpora<ul>
+        <li><a href="http://bit.ly/2KsFQxm">Subtitle pairs (600k+)</a></li>
+        <li>Sentences pairs (45k+): <a href="http://bit.ly/2Z8q0fo">GNOME</a>, <a href="http://bit.ly/2WLY6bI">KDE</a>,
+          and <a href="http://bit.ly/2wLVZGt">Ubuntu</a> </li>
+      </ul>
+    </li>
+    <li><a href="http://bit.ly/2EQZ7oM">Filtered Sinhala Wikipedia (155k+ sentences)</a></li>
+    <li><a href="http://bit.ly/2ZaQFZo">Sinhala common crawl (5m+ sentences)</a></li>
+    <li><a href="https://github.com/nlpc-uom/Sinhala-POS-Data">Sinhala-POS-Data</a></li>
+    <li><a
+        href="https://github.com/nlpc-uom/Sinhala-Tamil-Aligned-Parallel-Corpus">Sinhala-Tamil-Aligned-Parallel-Corpus</a>
+    </li>
+    <li><a href="https://github.com/google/language-resources/blob/master/si/data/lexicon.tsv">Sinhala Lexicon</a></li>
+    <li><a href="https://github.com/google/language-resources/tree/master/si/textnorm">Sinhala TTS Textnorm grammer</a>
+    </li>
+    <li><a href="https://github.com/google/language-resources/blob/master/si/festvox/ipa_phonology.json">Sinhala TTS
+        Phonology</a></li>
+    <li><a href="https://github.com/google/language-resources/blob/master/si/si-si_FONIPA.txt">Sinhala G2P</a></li>
+  </ul>
+  <h4 id="tools">Tools</h4>
+  <ul>
+    <li><a href="https://ucsc.cmb.ac.lk/machine-translation-system-sinhala-tamil-language-pair/">Machine Translation
+        System for Sinhala -Tamil Language Pair</a></li>
+    <li><a href="https://github.com/precog-iiitd/MIDAS-NMT-English-Tamil">MIDAS-NMT-English-Tamil</a></li>
+    <li><a href="https://github.com/theisuru/sentiment-tagger">Sentiment Analysis of Sinhala News Comments</a></li>
+    <li><a href="https://github.com/cnlpuom">National Langauges Processing Centre (UoM) on Github</a></li>
+    <li><a href="https://github.com/suralk/SinhalaSentenceSimilarityMeasurement">Sinhala Sentence Similarity
+        Measurement</a></li>
+    <li><a
+        href="https://github.com/Jenarthanan14/Tamil-Sinhala-Emotion-Analysis/tree/master/TamilEmotionTweetScraper">Tamil
+        Emotion Tweet Scraper</a></li>
+    <li><a href="https://github.com/ysenarath/SinLing">Morphological analyser and tokenizer for Sinhala nouns
+        (SinLing)</a></li>
+    <li><a href="https://github.com/nlpc-uom/Sinhala-and-Tamil-NER">Sinhala-and-Tamil-NER</a></li>
+    <li><a href="https://github.com/nlpc-uom/Tamil-Tokeniser">Tamil-Tokeniser</a></li>
+    <li><a href="https://github.com/ysenarath/sinling/tree/master/bin">Sinhala-Tokeniser</a></li>
+    <li><a href="https://github.com/theisuru/sentiment-tagger/tree/master/corpus/analyzed/saved_models">Sinhala skipgram
+        model</a></li>
+    <li><a href="https://github.com/google/language-resources/tree/master/si/festvox">Sinhala TTS Recipe</a></li>
+    <li><a href="https://github.com/google/asr-recipes">Sinhala ASR Recipe</a></li>
+    <li><a href="https://stanfordnlp.github.io/stanza/index.html">Stanza - Python NLP package for liguistic analysis</a>
+      - Supports multiple languages including tamil</li>
+  </ul>
+  <h4 id="research-groups">Research Groups</h4>
+  <ul>
+    <li><a href="https://www.language.lk/en/">Local Languages Working Group by LK Domain Registry</a></li>
+    <li><a href="https://www.mrt.ac.lk/web/nlp">NLP gruop of UoM</a></li>
+    <li><a href="http://ltrl.ucsc.lk/">Language Technology Research Laboratory (LTRL) of UCSC</a></li>
+  </ul>
+  <!-- Converted HTML (from Markdown) ends here. -->
+</body>
+
 </html>


### PR DESCRIPTION
This PR addresses the following changes 
- add tool; Stanza by Stanford NLP Group - [link here](https://stanfordnlp.github.io/stanza/index.html)
- update link to SinMin dataset - added the [OSF link](https://osf.io/a5quv/) and link to author's page. Previous listed link was not working
- fix file formatting  